### PR TITLE
Convert worklet class to struct

### DIFF
--- a/tut_mag_grad.cxx
+++ b/tut_mag_grad.cxx
@@ -11,9 +11,8 @@
 
 #include <vtkm/worklet/WorkletMapField.h>
 
-class ComputeMagnitude : public vtkm::worklet::WorkletMapField
+struct ComputeMagnitude : vtkm::worklet::WorkletMapField
 {
-public:
   using ControlSignature = void(FieldIn inputVectors, FieldOut outputMagnitudes);
 
   VTKM_EXEC void operator()(const vtkm::Vec3f& inVector, vtkm::FloatDefault& outMagnitude) const


### PR DESCRIPTION
Starting with a struct saves us declaring things public (everything
starts public) and makes it easier to follow.