### PR TITLE
fix tut_error_handling exit code

### DIFF
--- a/tut_error_handling.cxx
+++ b/tut_error_handling.cxx
@@ -25,13 +25,14 @@ int main(int argc, char** argv)
 
     vtkm::cont::DataSet ds_from_mc = contour.Execute(ds_from_file);
     vtkm::io::writer::VTKDataSetWriter writer("out_mc.vtk");
-    writer.WriteDataSet(ds_from_mc);
+    writer.WriteDataSet(ds_from_mc); //! Exception here
+
+    std::cerr << "FAILED TEST, Exception not raised" << std::endl;
   }
   catch (const vtkm::cont::Error& error)
   {
-    std::cerr << "VTK-m error occurred!: " << error.GetMessage() << std::endl;
-    return 1;
+    return 0;
   }
 
-  return 0;
+  return 1;
 }


### PR DESCRIPTION
__VTKm__ version: Current master HEAD

Currently after building the test files I get this:

```
→ find ./ -type f -executable -exec echo "'{}'" \; -exec ./'{}' \;
'./CMakeFiles/3.16.4/CompilerIdCXX/a.out'
'./CMakeFiles/3.16.4/CMakeDetermineCompilerABI_C.bin'
'./CMakeFiles/3.16.4/CompilerIdC/a.out'
'./CMakeFiles/3.16.4/CMakeDetermineCompilerABI_CXX.bin'
'./tut_2filters'
'./tut_io'
'./tut_contour'
'./tut_logging'
'./tut_contour_2fields'
'./tut_rendering'
'./tut_error_handling'
VTK-m error occurred!: No field with requested name: c1
'./tut_point_to_cell'
'./tut_mag_grad'
'./tut_extract_edges'
```
Looking into the code, I see that the error handling throws an error message if an exception is raised when trying to read an empty DataSet not associated with a DatasetReader (which I suspect that it is the appropiate behavior).

To correct this I swapped the error codes and changed when is the error message shown.

Now the output of all the tests are:

```
 './CMakeFiles/3.16.4/CompilerIdCXX/a.out'
'./CMakeFiles/3.16.4/CMakeDetermineCompilerABI_C.bin'
'./CMakeFiles/3.16.4/CompilerIdC/a.out'
'./CMakeFiles/3.16.4/CMakeDetermineCompilerABI_CXX.bin'
'./tut_2filters'
'./tut_io'
'./tut_contour'
'./tut_logging'
'./tut_contour_2fields'
'./tut_rendering'
'./tut_error_handling'
'./tut_point_to_cell'
'./tut_mag_grad'
'./tut_extract_edges'
```